### PR TITLE
Exception for missing credentials implementation

### DIFF
--- a/src/main/java/com/bandwidth/sdk/BandwidthClient.java
+++ b/src/main/java/com/bandwidth/sdk/BandwidthClient.java
@@ -1,11 +1,20 @@
 package com.bandwidth.sdk;
 
+import com.bandwidth.sdk.exception.MissingCredentialsException;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.*;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.NameValuePair;
+import org.apache.http.StatusLine;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.*;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.FileEntity;
@@ -16,7 +25,11 @@ import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.json.simple.JSONObject;
 
-import java.io.*;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -346,13 +359,18 @@ public class BandwidthClient implements Client{
      * @throws IOException unexpected exception.
      */
     protected RestResponse performRequest(final HttpUriRequest request) throws IOException {
-        try {
-            return RestResponse.createRestResponse(httpClient.execute(request)); 
-        } catch (final ClientProtocolException e1) {
-            throw new IOException(e1);
-        } catch (final IOException e1) {
-            throw new IOException(e1);
+        RestResponse restResponse = RestResponse.createRestResponse(httpClient.execute(request));
+
+        if (restResponse.status == HttpStatus.SC_UNAUTHORIZED){
+            if (this.usersUri == null || this.usersUri.isEmpty()
+                    || this.token == null || this.token.isEmpty()
+                    || this.secret == null || this.secret.isEmpty()){
+
+                throw new MissingCredentialsException();
+            }
         }
+
+        return restResponse;
     }
 
     /**

--- a/src/main/java/com/bandwidth/sdk/BandwidthClient.java
+++ b/src/main/java/com/bandwidth/sdk/BandwidthClient.java
@@ -5,7 +5,6 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
-import org.apache.http.HttpStatus;
 import org.apache.http.NameValuePair;
 import org.apache.http.StatusLine;
 import org.apache.http.client.ClientProtocolException;
@@ -359,18 +358,15 @@ public class BandwidthClient implements Client{
      * @throws IOException unexpected exception.
      */
     protected RestResponse performRequest(final HttpUriRequest request) throws IOException {
-        RestResponse restResponse = RestResponse.createRestResponse(httpClient.execute(request));
 
-        if (restResponse.status == HttpStatus.SC_UNAUTHORIZED){
-            if (this.usersUri == null || this.usersUri.isEmpty()
-                    || this.token == null || this.token.isEmpty()
-                    || this.secret == null || this.secret.isEmpty()){
+        if (this.usersUri == null || this.usersUri.isEmpty()
+                || this.token == null || this.token.isEmpty()
+                || this.secret == null || this.secret.isEmpty()) {
 
-                throw new MissingCredentialsException();
-            }
+            throw new MissingCredentialsException();
         }
 
-        return restResponse;
+        return RestResponse.createRestResponse(httpClient.execute(request));
     }
 
     /**

--- a/src/main/java/com/bandwidth/sdk/exception/MissingCredentialsException.java
+++ b/src/main/java/com/bandwidth/sdk/exception/MissingCredentialsException.java
@@ -1,0 +1,16 @@
+package com.bandwidth.sdk.exception;
+
+import java.io.IOException;
+
+public class MissingCredentialsException extends IOException {
+
+    private static final long serialVersionUID = 8463765824822860908L;
+
+    public MissingCredentialsException() {
+        super("Missing credentials. There are 3 ways to set these credentials:\n" +
+                " *\n" +
+                " * 1. Via environment variables\n" +
+                " * 2. Via Java VM System Properties, set as -D arguments on the VM command line.\n" +
+                " * 3. Directly by way of a method call on the BandwidthClient object");
+    }
+}

--- a/src/test/java/com/bandwidth/sdk/CredentialsTest.java
+++ b/src/test/java/com/bandwidth/sdk/CredentialsTest.java
@@ -1,0 +1,36 @@
+package com.bandwidth.sdk;
+
+import com.bandwidth.sdk.exception.MissingCredentialsException;
+import com.bandwidth.sdk.model.Account;
+import com.bandwidth.sdk.model.BaseModelTest;
+import com.bandwidth.sdk.model.Domain;
+import com.bandwidth.sdk.model.Endpoint;
+import org.junit.Test;
+
+/**
+ * Test to validate that SDK throws specific exception for missing credentials
+ *
+ * This test class has one test for each HTTP operation (GET, POST, PUT, DELETE)
+ */
+public class CredentialsTest extends BaseModelTest {
+
+    @Test(expected = MissingCredentialsException.class)
+    public void testGetAccountWithoutCredentials() throws Exception {
+        Account.get().getAccountInfo();
+    }
+
+    @Test(expected = MissingCredentialsException.class)
+    public void testCreateDomainWithoutCredentials() throws Exception {
+        Domain.create("TestDomain");
+    }
+
+    @Test(expected = MissingCredentialsException.class)
+    public void testUpdateDomainWithoutCredentials() throws Exception {
+        Domain.update("DomainId", "NewDescription");
+    }
+
+    @Test(expected = MissingCredentialsException.class)
+    public void testDeleteEndpointWithoutCredentials() throws Exception {
+        Endpoint.delete("111111", "222222");
+    }
+}

--- a/src/test/java/com/bandwidth/sdk/model/EndpointTest.java
+++ b/src/test/java/com/bandwidth/sdk/model/EndpointTest.java
@@ -1,8 +1,8 @@
 package com.bandwidth.sdk.model;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
-
+import com.bandwidth.sdk.AppPlatformException;
+import com.bandwidth.sdk.MockClient;
+import com.bandwidth.sdk.RestResponse;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -10,9 +10,8 @@ import org.json.simple.parser.ParseException;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.bandwidth.sdk.AppPlatformException;
-import com.bandwidth.sdk.MockClient;
-import com.bandwidth.sdk.RestResponse;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
 
 public class EndpointTest {
 
@@ -50,7 +49,10 @@ public class EndpointTest {
     
     @Test(expected = AppPlatformException.class)
     public void deleteEndpointByInvalidEndpointId() throws Exception {
-        Endpoint.delete(domain.getId(), "111111");
+        final RestResponse response = new RestResponse();
+        mockClient.setRestResponse(response);
+        response.setStatus(404);
+        Endpoint.delete(mockClient, domain.getId(), "111111");
     }
     
     @Test


### PR DESCRIPTION
This implementation is regarding story https://inetcatapult.atlassian.net/browse/CAT-3252

If we get a 401 response from API, verify if credentials are not filled, so throws a specific exception (MissingCredentialsException) with instruction on how to set credentials.