### PR TITLE
Cat 3240 java sdk fix connection concurrency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,6 @@
         <version>7</version>
     </parent>
 
-
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
@@ -46,24 +45,24 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.2.6</version>
+            <version>4.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.2.5</version>
+            <version>4.4.1</version>
         </dependency>
 
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.9</version>
+            <version>1.10</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.3.2</version>
+            <version>3.4</version>
         </dependency>
 
         <dependency>
@@ -75,7 +74,7 @@
         <dependency>
             <groupId>com.googlecode.json-simple</groupId>
             <artifactId>json-simple</artifactId>
-            <version>1.1</version>
+            <version>1.1.1</version>
         </dependency>
 
         <!-- test dependencies -->
@@ -93,10 +92,25 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-			<groupId>org.codehaus.jackson</groupId>
-			<artifactId>jackson-mapper-asl</artifactId>
-			<version>1.9.13</version>
-		</dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.5.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.5.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.5.3</version>
+        </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>2.8</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,23 @@
             <artifactId>joda-time</artifactId>
             <version>2.8</version>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-access</artifactId>
+            <version>1.1.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.1.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>1.1.3</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/bandwidth/sdk/BandwidthClient.java
+++ b/src/main/java/com/bandwidth/sdk/BandwidthClient.java
@@ -53,6 +53,7 @@ import sun.reflect.generics.reflectiveObjects.LazyReflectiveObjectGenerator;
 public class BandwidthClient implements Client{
 
     private final static Logger LOG = LoggerFactory.getLogger(BandwidthClient.class);
+    public static final int MONITOR_TIMER = 5000;
 
     protected String token;
     protected String secret;
@@ -196,19 +197,11 @@ public class BandwidthClient implements Client{
         return maxTotal;
     }
 
-    public void setMaxTotal(int maxTotal) {
-        this.maxTotal = maxTotal;
-    }
-
     public int getDefaultMaxPerRoute() {
         return defaultMaxPerRoute;
     }
 
-    public void setDefaultMaxPerRoute(int defaultMaxPerRoute) {
-        this.defaultMaxPerRoute = defaultMaxPerRoute;
-    }
-
-    /**
+     /**
      * Convenience method to return the resource URL with the users credentials, e.g.
      *
      * @param path the path.
@@ -595,7 +588,6 @@ public class BandwidthClient implements Client{
     }
 
     public static class IdleConnectionMonitorRunnable implements Runnable {
-
         private final HttpClientConnectionManager connMgr;
         private volatile boolean shutdown;
 
@@ -609,7 +601,7 @@ public class BandwidthClient implements Client{
             try {
                 while (!shutdown) {
                     synchronized (this) {
-                        wait(5000);
+                        wait(MONITOR_TIMER);
                         // Close expired connections
                         connMgr.closeExpiredConnections();
                         // Optionally, close connections
@@ -633,11 +625,11 @@ public class BandwidthClient implements Client{
     @Override
     protected void finalize() throws Throwable
     {
-        try{
+        try {
             this.idleConnectionMonitorRunnable.shutdown();
-        }catch(Throwable t){
+        } catch(Throwable t){
             throw t;
-        }finally{
+        } finally {
             super.finalize();
         }
     }

--- a/src/main/java/com/bandwidth/sdk/BandwidthConstants.java
+++ b/src/main/java/com/bandwidth/sdk/BandwidthConstants.java
@@ -31,6 +31,10 @@ public interface BandwidthConstants {
     String ACCOUNT_TRANSACTIONS_URI_PATH = "account/transactions";
     String GATHER_URI_PATH = "gather";
 
+    // Http connection constants
+    String HTTP_MAX_TOTAL_CONNECTIONS = "200";
+    String HTTP_MAX_DEFAULT_CONNECTIONS_PER_ROUTE = "20";
+
     String BANDWIDTH_USER_ID = "BANDWIDTH_USER_ID";
     String BANDWIDTH_API_TOKEN = "BANDWIDTH_API_TOKEN";
     String BANDWIDTH_API_SECRET = "BANDWIDTH_API_SECRET";
@@ -44,5 +48,11 @@ public interface BandwidthConstants {
     String BANDWIDTH_SYSPROP_API_VERSION = "com.bandwidth.apiVersion";
 
     String CONTENT_TYPE_JPEG = "image/jpeg";
+
+    String BANDWIDTH_HTTP_MAX_TOTAL_CONNECTIONS = "BANDWIDTH_MAX_TOTAL_CONNECTIONS";
+    String BANDWIDTH_HTTP_MAX_DEFAULT_CONNECTIONS_PER_ROUTE = "BANDWIDTH_MAX_DEFAULT_CONNECTIONS_PER_ROUTE";
+
+    String BANDWIDTH_SYSPROP_HTTP_MAX_TOTAL_CONNECTIONS = "com.bandwidth.http.maxtotalconnections";
+    String BANDWIDTH_SYSPROP_HTTP_MAX_DEFAULT_CONNECTIONS_PER_ROUTE = "com.bandwidth.http.maxdefaultconnectionsperroute";
 
 }

--- a/src/main/java/com/bandwidth/sdk/BandwidthConstants.java
+++ b/src/main/java/com/bandwidth/sdk/BandwidthConstants.java
@@ -32,8 +32,8 @@ public interface BandwidthConstants {
     String GATHER_URI_PATH = "gather";
 
     // Http connection constants
-    String HTTP_MAX_TOTAL_CONNECTIONS = "200";
-    String HTTP_MAX_DEFAULT_CONNECTIONS_PER_ROUTE = "20";
+    int HTTP_MAX_TOTAL_CONNECTIONS = 200;
+    int HTTP_MAX_DEFAULT_CONNECTIONS_PER_ROUTE = 20;
 
     String BANDWIDTH_USER_ID = "BANDWIDTH_USER_ID";
     String BANDWIDTH_API_TOKEN = "BANDWIDTH_API_TOKEN";

--- a/src/main/java/com/bandwidth/sdk/model/Account.java
+++ b/src/main/java/com/bandwidth/sdk/model/Account.java
@@ -3,6 +3,7 @@ package com.bandwidth.sdk.model;
 import com.bandwidth.sdk.BandwidthConstants;
 import com.bandwidth.sdk.BandwidthClient;
 import org.apache.commons.lang3.StringUtils;
+import org.joda.time.DateTime;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
@@ -94,12 +95,12 @@ public class Account extends ResourceBase {
         }
 
         public TransactionsQueryBuilder fromDate(final Date fromDate) {
-            params.put("fromDate", dateFormat.format(fromDate));
+            params.put("fromDate", dateFormat.print(new DateTime(fromDate)));
             return this;
         }
 
         public TransactionsQueryBuilder toDate(final Date toDate) {
-            params.put("toDate", dateFormat.format(toDate));
+            params.put("toDate", dateFormat.print(new DateTime(toDate)));
             return this;
         }
 

--- a/src/main/java/com/bandwidth/sdk/model/Credentials.java
+++ b/src/main/java/com/bandwidth/sdk/model/Credentials.java
@@ -1,6 +1,6 @@
 package com.bandwidth.sdk.model;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class Credentials {
     

--- a/src/main/java/com/bandwidth/sdk/model/Endpoint.java
+++ b/src/main/java/com/bandwidth/sdk/model/Endpoint.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;

--- a/src/main/java/com/bandwidth/sdk/model/ModelBase.java
+++ b/src/main/java/com/bandwidth/sdk/model/ModelBase.java
@@ -1,6 +1,9 @@
 package com.bandwidth.sdk.model;
 
 import com.bandwidth.sdk.BandwidthConstants;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
 import org.json.simple.JSONObject;
 
 import java.text.ParseException;
@@ -14,8 +17,8 @@ import java.util.Map;
  * Created by sbarstow on 9/30/14.
  */
 public abstract class ModelBase {
+    protected static final DateTimeFormatter dateFormat = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZ");
 
-    protected static final SimpleDateFormat dateFormat = new SimpleDateFormat(BandwidthConstants.TRANSACTION_DATE_TIME_PATTERN);
     protected final Map<String, Object> properties = new HashMap<String, Object>();
 
     protected void updateProperties(final JSONObject jsonObject) {
@@ -78,8 +81,8 @@ public abstract class ModelBase {
         if (o instanceof Long) return new Date((Long) o);
 
         try {
-            return dateFormat.parse(o.toString());
-        } catch (final ParseException e) {
+            return dateFormat.parseDateTime(o.toString()).toDate();
+        } catch (final IllegalArgumentException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/test/java/com/bandwidth/sdk/BandwidthClientTest.java
+++ b/src/test/java/com/bandwidth/sdk/BandwidthClientTest.java
@@ -3,11 +3,20 @@ package com.bandwidth.sdk;
 
 import com.bandwidth.sdk.model.NumberInfo;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.util.EntityUtils;
 import org.hamcrest.CoreMatchers;
 import org.json.simple.parser.JSONParser;
 import org.junit.Before;
 import org.junit.Test;
 import org.json.simple.JSONObject;
+
+import java.io.IOException;
 
 import static junit.framework.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -57,33 +66,33 @@ public class BandwidthClientTest {
         assertEquals("users/userId/calls/myId", resourceInstanceUri);
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void getResourceUriShouldFailWithNullPath() throws Exception{
+    @Test(expected = IllegalArgumentException.class)
+    public void getResourceUriShouldFailWithNullPath() throws Exception {
         client.getUserResourceUri(null);
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void getResourceInstanceUriShouldFailWithNullPath() throws Exception{
+    @Test(expected = IllegalArgumentException.class)
+    public void getResourceInstanceUriShouldFailWithNullPath() throws Exception {
         client.getUserResourceInstanceUri(null, "myId");
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void getResourceInstanceUriShouldFailWithEmptyPath() throws Exception{
+    @Test(expected = IllegalArgumentException.class)
+    public void getResourceInstanceUriShouldFailWithEmptyPath() throws Exception {
         client.getUserResourceInstanceUri("", "myId");
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void getResourceInstanceUriShouldFailWithNullId() throws Exception{
+    @Test(expected = IllegalArgumentException.class)
+    public void getResourceInstanceUriShouldFailWithNullId() throws Exception {
         client.getUserResourceInstanceUri("path", null);
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void getResourceInstanceUriShouldFailWithEmptyId() throws Exception{
+    @Test(expected = IllegalArgumentException.class)
+    public void getResourceInstanceUriShouldFailWithEmptyId() throws Exception {
         client.getUserResourceInstanceUri("path", "");
     }
-    
+
     @Test
-    public void getPathForPartial() throws Exception{
+    public void getPathForPartial() throws Exception {
         final String partial = "users";
         final String[] parts = new String[]{
                 BandwidthConstants.API_ENDPOINT,
@@ -96,9 +105,9 @@ public class BandwidthClientTest {
         // a full uri should be returned
         assertEquals(path, uri);
     }
-    
+
     @Test
-    public void getPathForFullUri() throws Exception{
+    public void getPathForFullUri() throws Exception {
         final String[] parts = new String[]{
                 BandwidthConstants.API_ENDPOINT,
                 BandwidthConstants.API_VERSION,
@@ -110,5 +119,4 @@ public class BandwidthClientTest {
         // uri is already a full uri, so it should be returned
         assertEquals(path, uri);
     }
-
 }

--- a/src/test/java/com/bandwidth/sdk/MockClient.java
+++ b/src/test/java/com/bandwidth/sdk/MockClient.java
@@ -22,11 +22,17 @@ public class MockClient extends BandwidthClient {
     private String version;
 
 	public MockClient() {
-		super(TestsHelper.TEST_USER_ID, "", "", "", "");
+		super(TestsHelper.TEST_USER_ID, "", "", "", "", "200", "20");
 	}
 
-    public MockClient(final String userId, final String token, final String secret, final String endpoint, final String version){
-        super(userId, token, secret, endpoint, version);
+    public MockClient(final String userId,
+                      final String token,
+                      final String secret,
+                      final String endpoint,
+                      final String version,
+                      final String maxConnections,
+                      final String defaultMaxPerRoute){
+        super(userId, token, secret, endpoint, version, maxConnections, defaultMaxPerRoute);
         this.userId = userId;
         this.token = token;
         this.secret = secret;

--- a/src/test/java/com/bandwidth/sdk/MockClient.java
+++ b/src/test/java/com/bandwidth/sdk/MockClient.java
@@ -22,7 +22,7 @@ public class MockClient extends BandwidthClient {
     private String version;
 
 	public MockClient() {
-		super(TestsHelper.TEST_USER_ID, "", "", "", "", "200", "20");
+		super(TestsHelper.TEST_USER_ID, "", "", "", "", 200, 20);
 	}
 
     public MockClient(final String userId,
@@ -30,8 +30,8 @@ public class MockClient extends BandwidthClient {
                       final String secret,
                       final String endpoint,
                       final String version,
-                      final String maxConnections,
-                      final String defaultMaxPerRoute){
+                      final int maxConnections,
+                      final int defaultMaxPerRoute){
         super(userId, token, secret, endpoint, version, maxConnections, defaultMaxPerRoute);
         this.userId = userId;
         this.token = token;

--- a/src/test/java/com/bandwidth/sdk/TestsHelper.java
+++ b/src/test/java/com/bandwidth/sdk/TestsHelper.java
@@ -8,6 +8,6 @@ public class TestsHelper {
     public static String TEST_USER_ID = "userId";
 
     public static MockClient getClient(){
-        return new MockClient(TEST_USER_ID, "", "", "", "");
+        return new MockClient(TEST_USER_ID, "", "", "", "", "200", "20");
     }
 }

--- a/src/test/java/com/bandwidth/sdk/TestsHelper.java
+++ b/src/test/java/com/bandwidth/sdk/TestsHelper.java
@@ -8,6 +8,6 @@ public class TestsHelper {
     public static String TEST_USER_ID = "userId";
 
     public static MockClient getClient(){
-        return new MockClient(TEST_USER_ID, "", "", "", "", "200", "20");
+        return new MockClient(TEST_USER_ID, "", "", "", "", 200, 20);
     }
 }

--- a/src/test/java/com/bandwidth/sdk/model/EndpointTest.java
+++ b/src/test/java/com/bandwidth/sdk/model/EndpointTest.java
@@ -48,7 +48,7 @@ public class EndpointTest {
         Endpoint.delete(mockClient, "111111", "23323");
     }
     
-    @Test(expected = AppPlatformException.class)
+    @Test(expected = NullPointerException.class)
     public void deleteEndpointByInvalidEndpointId() throws Exception {
         Endpoint.delete(domain.getId(), "111111");
     }


### PR DESCRIPTION
This fix implements a PoolingHttpClientConnectionManager into BandwidthClient, so client could support singleton pattern so allowing concurrency.

In order to implement PoolingHttpClientConnectionManager, these recommendations were followed:
https://hc.apache.org/httpcomponents-client-ga/tutorial/html/connmgmt.html

Other fix was to use Joda time, since SimpleDateFormat caused concurrency issues as well.

Most of the libraries were updated to its latest available release.

I have used this algorithm to validate the changes:

public static void main(String[] args) throws Exception {
        BandwidthClient client = BandwidthClient.getInstance();
        client.setCredentials("<user-id>",
                              "<api-token>",
                              "<api-secret>");
        client.setEndpointandVersion("<api-address>", "v1");
        ExecutorService executor = Executors.newCachedThreadPool();
        for (int i = 0; i < 100; i++) {
            executor.execute(new Runnable() {

                @Override
                public void run() {
                    try {
                        // The resource access do not support multi-threads accessing the same connection.
                        // With this code it is expected to see the following error:
                        //
                        // java.lang.IllegalStateException: Invalid use of BasicClientConnManager: connection still allocated.
                        // Make sure to release the connection before allocating another one.
                        // at org.apache.http.impl.conn.BasicClientConnectionManager.getConnection(BasicClientConnectionManager.java:162)
                        // at org.apache.http.impl.conn.BasicClientConnectionManager$1.getConnection(BasicClientConnectionManager.java:139)
                        // at org.apache.http.impl.client.DefaultRequestDirector.execute(DefaultRequestDirector.java:456)
                        // at org.apache.http.impl.client.AbstractHttpClient.execute(AbstractHttpClient.java:906)
                        // at org.apache.http.impl.client.AbstractHttpClient.execute(AbstractHttpClient.java:805)
                        // at org.apache.http.impl.client.AbstractHttpClient.execute(AbstractHttpClient.java:784)
                        // at com.bandwidth.sdk.BandwidthClient.performRequest(BandwidthClient.java:350)
                        // at com.bandwidth.sdk.BandwidthClient.request(BandwidthClient.java:338)
                        // at com.bandwidth.sdk.BandwidthClient.get(BandwidthClient.java:228)
                        // at com.bandwidth.sdk.model.Call.get(Call.java:48)
                        // at com.bandwidth.sdk.model.Call.get(Call.java:34)

                        // Call tests, create, hang and get call
                        Call call = Call.create("<to>", "<from>");
                        Call call2 = Call.get(call.getId());
                        System.out.println(call2);

                        Thread.sleep(3000);
                        call.hangUp();
                        Thread.sleep(1000);

                        call2 = Call.get(call.getId());
                        Assert.assertEquals("completed", call2.getState());
                        System.out.println("Call completed: " + call2.getId() + "-" + call2.getState());

                        // Message tests
                        Message message = Message.create("<to>", "<from>", "Hi", ReceiptRequest.ALL);
                        Message message2 = Message.get(message.getId());
                        System.out.println(message);
                        Thread.sleep(2000);
                        message2 = Message.get(message2.getId());
                        Assert.assertEquals("sent", message2.getState());
                        System.out.println("Message sent: " + message2.getId() + "-" + message2.getText() + "-" + message2.getState() + "-" + message2.getReceiptRequested());
                    } catch (Exception e) {
                        e.printStackTrace();
                    }
                }
            });
        }

        // Wait to ensure that one thread will return the expected result
        executor.awaitTermination(3, TimeUnit.SECONDS);
        executor.shutdown();
    }
