### PR TITLE
Update dependency to latest on maven 1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Use the following dependency in your project:
        <dependency>
           <groupId>com.bandwidth.sdk</groupId>
           <artifactId>bandwidth-java-sdk</artifactId>
-          <version>1.0</version>
+          <version>1.10</version>
           <scope>compile</scope>
        </dependency>
 


### PR DESCRIPTION
Hi guys, 

I found that the README.md is out of date. The current version in mavenRepo is 1.10.

Also there's an issue https://github.com/bandwidthcom/java-bandwidth/issues/30 1.11-SNAPSHOT is not available on mavenRepo.

Which version is the right one to use with your current API version?

Thanks