### PR TITLE
Add javadocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Java SDK for [Bandwidth's App Platform](http://ap.bandwidth.com/?utm_medium=soci
 # Documentation
 [More Coming Soon]
 
+[Javadocs](http://www.javadoc.io/doc/com.bandwidth.sdk/bandwidth-java-sdk) Reference
+
 [Code Examples](https://github.com/bandwidthcom/java-bandwidth-examples)
 
 # Installing

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Java SDK for [Bandwidth's App Platform](http://ap.bandwidth.com/?utm_medium=soci
 # Documentation
 [More Coming Soon]
 
-[Javadocs](http://www.javadoc.io/doc/com.bandwidth.sdk/bandwidth-java-sdk) Reference
+[![Javadocs](http://www.javadoc.io/badge/com.bandwidth.sdk/bandwidth-java-sdk.svg)](http://www.javadoc.io/doc/com.bandwidth.sdk/bandwidth-java-sdk)
 
 [Code Examples](https://github.com/bandwidthcom/java-bandwidth-examples)
 


### PR DESCRIPTION
I added a link to the javadocs in the readme.  Using the maven central repository, the javadocs were auto generate and are hosted at http://www.javadoc.io/