### PR TITLE
New create() method to mirror node implementation

### DIFF
--- a/src/main/java/com/bandwidth/sdk/model/Message.java
+++ b/src/main/java/com/bandwidth/sdk/model/Message.java
@@ -133,6 +133,28 @@ public class Message extends ResourceBase {
     }
 
     /**
+     * Convenience factory method to send MMS messages.
+     *
+     * @param to the from number
+     * @param from the to number
+     * @param text the text
+     * @param media the url of the media item to send
+     * @return the message
+     * @throws Exception error.
+    */
+    public static Message create(final String to, final String from, final String text, final String media) throws Exception {
+
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put("to", to);
+        params.put("from", from);
+        params.put("text", text);
+		params.put("media", media);
+
+        return create(params);
+    }
+
+	
+    /**
      * Convenience factory method to send MMS messages. Create a MediaFile object using the Media upload method
      * and pass that in.
      *
@@ -145,7 +167,7 @@ public class Message extends ResourceBase {
      */
     public static Message create(final String to, final String from, final String text, final MediaFile media) throws Exception {
 
-        final Map<String, Object> params = new HashMap<String, Object>();
+    	final Map<String, Object> params = new HashMap<String, Object>();
         params.put("to", to);
         params.put("from", from);
         params.put("text", text);


### PR DESCRIPTION
Spent about a half hour trying to figure out how to send a picture.  The current implementation of passing a MediaFile was kind of confusing, especially since it's only using the content anyway.

Currently, just to insert a simple image, I have to add these 5 lines to create a MediaFile:
 
```
        String mediaUrl =  "https://s3.amazonaws.com/bwdemos/logo.png";
        Map<String,String> media = new HashMap<String, String>();
        media.put("content",mediaUrl);
        JSONObject json = new JSONObject(media);
        MediaFile file = new MediaFile(client, json);
```

Would be a nice QOL improvement to be able to just call it with the URL like you can with the node library.